### PR TITLE
Update the response (ExecutionResult) to Include the updated number of records 

### DIFF
--- a/src/main/java/com/amazon/rdsdata/client/ExecutionResult.java
+++ b/src/main/java/com/amazon/rdsdata/client/ExecutionResult.java
@@ -26,10 +26,12 @@ import static java.util.stream.Collectors.toList;
 public class ExecutionResult {
     private List<String> fieldNames;
     private List<Row> rows;
+    private Long numberOfRecordsUpdated;
 
-    ExecutionResult(List<ColumnMetadata> metadata, List<List<Field>> fields) {
+    ExecutionResult(List<ColumnMetadata> metadata, List<List<Field>> fields, Long numberOfRecordsUpdated) {
         this.fieldNames = extractFieldNames(metadata);
         this.rows = convertToRows(fields);
+        this.numberOfRecordsUpdated = numberOfRecordsUpdated;
     }
 
     private List<String> extractFieldNames(List<ColumnMetadata> metadata) {
@@ -50,6 +52,15 @@ public class ExecutionResult {
         return records.stream()
                 .map(Row::new)
                 .collect(toList());
+    }
+
+    /**
+     * Will return the number of records inserted/updated by the query.
+     *
+     * @return the number of records updated.
+     */
+    public Long getNumberOfRecordsUpdated() {
+        return numberOfRecordsUpdated;
     }
 
     /**

--- a/src/main/java/com/amazon/rdsdata/client/RdsDataClient.java
+++ b/src/main/java/com/amazon/rdsdata/client/RdsDataClient.java
@@ -126,7 +126,8 @@ public class RdsDataClient {
                         .withDecimalReturnType(DecimalReturnType.STRING))
                 .withIncludeResultMetadata(true);
         val response = rdsDataService.executeStatement(request);
-        return new ExecutionResult(response.getColumnMetadata(), response.getRecords());
+        return new ExecutionResult(response.getColumnMetadata(), response.getRecords(),
+                response.getNumberOfRecordsUpdated());
     }
 
     ExecutionResult batchExecuteStatement(String transactionId, String sql, List<Map<String, Object>> params) {
@@ -138,7 +139,7 @@ public class RdsDataClient {
                 .withTransactionId(transactionId)
                 .withParameterSets(toSqlParameterSets(params));
         rdsDataService.batchExecuteStatement(request);
-        return new ExecutionResult(emptyList(), emptyList());
+        return new ExecutionResult(emptyList(), emptyList(), 0L);
     }
 
     private List<SqlParameter> toSqlParameterList(Map<String, Object> params) {

--- a/src/test/java/com/amazon/rdsdata/client/MapToListTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/MapToListTests.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.rdsdata.model.Field;
 import com.google.common.collect.ImmutableList;
 import lombok.Value;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.rdsdata.client.testutil.MockingTools.mockColumn;
@@ -27,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class MapToListTests extends TestBase {
     @Test
     void shouldMapViaAllArgsConstructor() {
-        mockReturnValues(
+        mockReturnValues(NUMBER_OF_RECORDS_UPDATED,
                 ImmutableList.of( // first row
                         mockColumn("intField", new Field().withLongValue(1L)),
                         mockColumn("stringField", new Field().withStringValue("hello"))
@@ -36,10 +37,10 @@ public class MapToListTests extends TestBase {
                         mockColumn("stringField", new Field().withStringValue("world"))
                 ));
 
-        val result = client.forSql("SELECT *")
-                .execute()
-                .mapToList(TestBean.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
 
+        val result = executionResult.mapToList(TestBean.class);
         assertThat(result).containsExactly(
                 new TestBean(1, "hello"),
                 new TestBean(2, "world"));

--- a/src/test/java/com/amazon/rdsdata/client/MapToSingleTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/MapToSingleTests.java
@@ -18,6 +18,7 @@ import com.amazon.rdsdata.client.testutil.TestBase;
 import com.amazonaws.services.rdsdata.model.Field;
 import lombok.Value;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.rdsdata.client.testutil.MockingTools.mockColumn;
@@ -28,14 +29,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MapToSingleTests extends TestBase {
     @Test
     void shouldMapToSingleObject() {
-        mockReturnValue(
+        mockReturnValue(NUMBER_OF_RECORDS_UPDATED,
                 mockColumn("intField", new Field().withLongValue(1L)),
                 mockColumn("stringField", new Field().withStringValue("hello")));
 
-        val result = client.forSql("SELECT *")
-                .execute()
-                .mapToSingle(TestBean.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
 
+        val result = executionResult.mapToSingle(TestBean.class);
         assertThat(result).isEqualTo(new TestBean(1, "hello"));
     }
 

--- a/src/test/java/com/amazon/rdsdata/client/MappingOutputViaAllArgsConstructorTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/MappingOutputViaAllArgsConstructorTests.java
@@ -17,6 +17,7 @@ package com.amazon.rdsdata.client;
 import com.amazon.rdsdata.client.testutil.TestBase;
 import com.amazonaws.services.rdsdata.model.Field;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.rdsdata.client.MappingException.ERROR_CANNOT_CREATE_INSTANCE_VIA_NOARGS;
@@ -27,12 +28,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MappingOutputViaAllArgsConstructorTests extends TestBase {
     @Test
     void shouldMapViaAllArgsConstructor() {
-        mockReturnValue(
+        mockReturnValue(NUMBER_OF_RECORDS_UPDATED,
                 mockColumn("stringValue", new Field().withStringValue("apple")),
                 mockColumn("intValue", new Field().withLongValue(15L)));
 
-        val result = client.forSql("SELECT *").execute().mapToSingle(ConstructorWithParameterNames.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
 
+        val result = executionResult.mapToSingle(ConstructorWithParameterNames.class);
         assertThat(result.result).isEqualTo("apple15");
     }
 

--- a/src/test/java/com/amazon/rdsdata/client/MappingOutputViaFieldsTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/MappingOutputViaFieldsTests.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.rdsdata.model.Field;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.rdsdata.client.MappingException.ERROR_CANNOT_ACCESS_FIELD;
@@ -34,12 +35,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MappingOutputViaFieldsTests extends TestBase {
     @Test
     void shouldMapToClassWithPublicFields() {
-        mockReturnValue(mockColumn("value", new Field().withStringValue("apple")));
+        mockReturnValue(NUMBER_OF_RECORDS_UPDATED, mockColumn("value", new Field().withStringValue("apple")));
 
-        val result = client.forSql("SELECT *")
-                .execute()
-                .mapToSingle(PublicFields.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
 
+        val result = executionResult.mapToSingle(PublicFields.class);
         assertThat(result.value).isEqualTo("apple");
     }
 

--- a/src/test/java/com/amazon/rdsdata/client/MappingOutputViaSettersTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/MappingOutputViaSettersTests.java
@@ -18,6 +18,7 @@ import com.amazon.rdsdata.client.testutil.TestBase;
 import com.amazonaws.services.rdsdata.model.Field;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import static com.amazon.rdsdata.client.MappingException.ERROR_NO_FIELD_OR_SETTER;
@@ -28,12 +29,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 public class MappingOutputViaSettersTests extends TestBase {
     @Test
     void shouldMapToFieldsOfDifferentType() {
-        mockReturnValue(mockColumn("stringValue", new Field().withStringValue("apple")));
+        mockReturnValue(NUMBER_OF_RECORDS_UPDATED, mockColumn("stringValue", new Field().withStringValue("apple")));
 
-        val result = client.forSql("SELECT *")
-                .execute()
-                .mapToSingle(Setter.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
 
+        val result = executionResult.mapToSingle(Setter.class);
         assertThat(result.value).isEqualTo("apple");
     }
 

--- a/src/test/java/com/amazon/rdsdata/client/OutputTypesTest.java
+++ b/src/test/java/com/amazon/rdsdata/client/OutputTypesTest.java
@@ -18,6 +18,7 @@ import com.amazon.rdsdata.client.testutil.TestBase;
 import com.amazonaws.services.rdsdata.model.Field;
 import lombok.NoArgsConstructor;
 import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -33,7 +34,7 @@ public class OutputTypesTest extends TestBase {
     @Test
     void shouldMapToFieldsOfDifferentType() {
         val bytes = new byte[] {1, 2, 3};
-        mockReturnValue(
+        mockReturnValue(NUMBER_OF_RECORDS_UPDATED,
                 mockColumn("stringValue", new Field().withStringValue("apple")),
                 mockColumn("byteValue", new Field().withLongValue(3L)),
                 mockColumn("intValue", new Field().withLongValue(4L)),
@@ -47,9 +48,10 @@ public class OutputTypesTest extends TestBase {
                 mockColumn("nullField", new Field().withIsNull(true))
         );
 
-        val result = client.forSql("SELECT *")
-                .execute()
-                .mapToSingle(FieldsOfDifferentTypes.class);
+        val executionResult = client.forSql("SELECT *").execute();
+        assertEquals(NUMBER_OF_RECORDS_UPDATED, executionResult.getNumberOfRecordsUpdated());
+
+        val result = executionResult.mapToSingle(FieldsOfDifferentTypes.class);
 
         assertThat(result.stringValue).isEqualTo("apple");
         assertThat(result.byteValue).isEqualTo((byte) 3);

--- a/src/test/java/com/amazon/rdsdata/client/RetrieveNumberOfRecordsTests.java
+++ b/src/test/java/com/amazon/rdsdata/client/RetrieveNumberOfRecordsTests.java
@@ -1,0 +1,76 @@
+package com.amazon.rdsdata.client;
+
+import static com.amazon.rdsdata.client.testutil.MockingTools.mockColumn;
+import com.amazon.rdsdata.client.testutil.TestBase;
+import com.amazonaws.services.rdsdata.model.Field;
+import com.google.common.collect.ImmutableList;
+import lombok.Value;
+import lombok.val;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+public class RetrieveNumberOfRecordsTests extends TestBase {
+
+    @Test
+    void shouldReturnUpdatedRecordsCountForParameterUpdate() {
+        long numberOfRecordsUpdated = 1;
+        mockReturnValue(numberOfRecordsUpdated);
+
+        val result = client.forSql("INSERT INTO tbl1(a, b, c) VALUES(?, ?, ?)", 1, 2, 3)
+                .execute();
+        assertEquals(numberOfRecordsUpdated, result.getNumberOfRecordsUpdated());
+    }
+
+    @Test
+    void shouldReturnUpdatedRecordsCountForDtoParamSingleUpdate() {
+        long numberOfRecordsUpdated = 1;
+        mockReturnValue(numberOfRecordsUpdated);
+
+        val dto = new Dto(1);
+
+        val result = client.forSql("INSERT INTO tbl1(a) VALUES(:value)")
+                .withParamSets(dto)
+                .execute();
+        assertEquals(numberOfRecordsUpdated, result.getNumberOfRecordsUpdated());
+    }
+
+    @Test
+    void shouldReturnZeroUpdatedRecordsCountForNoUpdates() {
+        mockReturnValue();
+
+        val dto = new Dto(1);
+
+        val result = client.forSql("INSERT INTO tbl1(a) VALUES(:value)")
+                .withParamSets(dto)
+                .execute();
+        assertEquals(0, result.getNumberOfRecordsUpdated());
+    }
+
+    @Test
+    void shouldReturnUpdatedRecordsCountForDtoParamBatchUpdate() {
+        mockReturnValues(
+                ImmutableList.of( // first row
+                        mockColumn("intField", new Field().withLongValue(1L))
+                ), ImmutableList.of( // 2nd row
+                        mockColumn("intField", new Field().withLongValue(2L))
+                ), ImmutableList.of( // 3rd row
+                        mockColumn("intField", new Field().withLongValue(3L))
+                ));
+
+        val dto1 = new Dto(1);
+        val dto2 = new Dto(2);
+        val dto3 = new Dto(3);
+
+        val result = client.forSql("INSERT INTO tbl1(a) VALUES(:value)")
+                .withParamSets(dto1, dto2, dto3)
+                .execute();
+        assertEquals(0, result.getNumberOfRecordsUpdated());
+
+    }
+
+    @Value
+    private static class Dto {
+        public final int value;
+    }
+}

--- a/src/test/java/com/amazon/rdsdata/client/testutil/MockingTools.java
+++ b/src/test/java/com/amazon/rdsdata/client/testutil/MockingTools.java
@@ -35,12 +35,14 @@ import static org.mockito.Mockito.when;
 
 @UtilityClass
 public class MockingTools {
-    public static void mockReturnValue(AWSRDSData mockClient, ColumnDefinition... columns) {
-        mockReturnValues(mockClient, asList(columns));
+    public static void mockReturnValue(AWSRDSData mockClient, Long numberOfRecordsUpdated,
+                                       ColumnDefinition... columns) {
+        mockReturnValues(mockClient, numberOfRecordsUpdated, asList(columns));
     }
 
     @SafeVarargs
-    public static void mockReturnValues(AWSRDSData mockClient, List<ColumnDefinition>... rows) {
+    public static void mockReturnValues(AWSRDSData mockClient, Long numberOfRecordsUpdated,
+                                        List<ColumnDefinition>... rows) {
         List<ColumnMetadata> metadataList = rows.length > 0 ? buildColumnMetadataList(rows[0]) : emptyList();
 
         val recordsList = Stream.of(rows)
@@ -52,7 +54,8 @@ public class MockingTools {
         when(mockClient.executeStatement(any(ExecuteStatementRequest.class)))
                 .thenReturn(new ExecuteStatementResult()
                         .withColumnMetadata(metadataList)
-                        .withRecords(recordsList));
+                        .withRecords(recordsList)
+                        .withNumberOfRecordsUpdated(numberOfRecordsUpdated));
     }
 
     private List<ColumnMetadata> buildColumnMetadataList(List<ColumnDefinition> columns) {
@@ -69,7 +72,8 @@ public class MockingTools {
         when(mockClient.executeStatement(any(ExecuteStatementRequest.class)))
                 .thenReturn(new ExecuteStatementResult()
                         .withColumnMetadata((Collection) null)
-                        .withRecords((Collection) null));
+                        .withRecords((Collection) null)
+                        .withNumberOfRecordsUpdated(null));
     }
 
     @AllArgsConstructor

--- a/src/test/java/com/amazon/rdsdata/client/testutil/TestBase.java
+++ b/src/test/java/com/amazon/rdsdata/client/testutil/TestBase.java
@@ -34,6 +34,7 @@ public class TestBase {
     protected static final String SAMPLE_DB = "mydb";
     protected static final String SAMPLE_RESOURCE_ARN = "arn:resource";
     protected static final String SAMPLE_SECRET_ARN = "arn:secret";
+    protected static final Long NUMBER_OF_RECORDS_UPDATED = 0L; // For reads, the number of updated records will be 0.
 
     protected RdsDataClient client;
     protected AWSRDSData originalClient = mock(AWSRDSData.class);
@@ -49,12 +50,22 @@ public class TestBase {
     }
 
     protected void mockReturnValue(MockingTools.ColumnDefinition... columns) {
-        MockingTools.mockReturnValue(originalClient, columns);
+        MockingTools.mockReturnValue(originalClient, NUMBER_OF_RECORDS_UPDATED, columns);
+    }
+
+
+    protected void mockReturnValue(Long numberOfRecordsUpdated, MockingTools.ColumnDefinition... columns) {
+        MockingTools.mockReturnValue(originalClient, numberOfRecordsUpdated, columns);
     }
 
     @SafeVarargs
     protected final void mockReturnValues(List<MockingTools.ColumnDefinition>... rows) {
-        MockingTools.mockReturnValues(originalClient, rows);
+        MockingTools.mockReturnValues(originalClient, NUMBER_OF_RECORDS_UPDATED, rows);
+    }
+
+    @SafeVarargs
+    protected final void mockReturnValues(Long numberOfRecordsUpdated, List<MockingTools.ColumnDefinition>... rows) {
+        MockingTools.mockReturnValues(originalClient, numberOfRecordsUpdated, rows);
     }
 
     protected final void returnNullMetadataAndResultSet() {


### PR DESCRIPTION
*Description of changes:*
Today, the ExecutionResult on an INSERT or UPDATE query will not return the number of records updated. Including the number of records updated will provide a way to consumers to know if the INSERT or UPDATE was successful. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
